### PR TITLE
docs: Luring link corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository serves as a hope for several important projects:
 
   * [loona](crates/loona/README.md) itself
   * [buffet](crates/buffet/README.md), its buffer management library
-  * [luring](crates/buffet/README.md), its io_uring abstraction on top of tokio
+  * [luring](crates/luring/README.md), its io_uring abstraction on top of tokio
   * [httpwg](crates/httpwg/README.md), an HTTP conformance suite (replacing h2spec)
 
 ### Funding


### PR DESCRIPTION
Just a small correction of the README to point to luring instead of the delicious buffet. 